### PR TITLE
Use planet express agent pool

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,19 +7,26 @@ variables:
 pool:
   name: "planet-express-docker-agents"
 
-steps:
-- task: Docker@2
-  inputs:
-    containerRegistry: 'DG Modules Container Registry'
-    command: 'login'
-    addPipelineData: false
-- script: ./build.sh $(netbootIP)
-  displayName: 'Build ubuntu base image'
-- task: Docker@2
-  inputs:
-    containerRegistry: 'DG Modules Container Registry'
-    repository: 'planetexpress/ubuntu-base'
-    command: 'Push'
-    Dockerfile: 'Dockerfile'
-    addPipelineData: false
-    tags: '22.04'
+stages:
+  - stage: Build
+    jobs:
+      - job: Build_squashfs
+        displayName: Build and propagate squashfs
+        workspace:
+          clean: all
+        steps:
+        - task: Docker@2
+          inputs:
+            containerRegistry: 'DG Modules Container Registry'
+            command: 'login'
+            addPipelineData: false
+        - script: ./build.sh $(netbootIP)
+          displayName: 'Build ubuntu base image'
+        - task: Docker@2
+          inputs:
+            containerRegistry: 'DG Modules Container Registry'
+            repository: 'planetexpress/ubuntu-base'
+            command: 'Push'
+            Dockerfile: 'Dockerfile'
+            addPipelineData: false
+            tags: '22.04'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,6 +4,9 @@ variables:
 - name: netbootIP
   value: 10.1.30.4
 
+pool:
+  name: "planet-express-docker-agents"
+
 steps:
 - task: Docker@2
   inputs:

--- a/install-kernel-package.sh
+++ b/install-kernel-package.sh
@@ -4,6 +4,7 @@ set -e
 # Use netbootIP as a variable to retreive latest kernel version from a custom-defined netbootserver
 if [[ $# -lt 1 ]]; then
         echo "Error: No arguments passed. Make sure to pass at least the Netboot IP Address"
+        exit 1
 else
         netbootIP="$1"
 fi


### PR DESCRIPTION
By switching to the another node-pool, the fallback kernel version shouldn't be used anymore.